### PR TITLE
Fixed the issue with paper statuses not showing up automatically

### DIFF
--- a/papers/admin.py
+++ b/papers/admin.py
@@ -55,16 +55,15 @@ class PaperAdmin(admin.ModelAdmin):
             list += '%s  ' % (unicode(d))
         return list
 
-    def get_queryset(self, request):
-        return Paper.objects.extra(
-            where=["papers_statusdata.id = ( "
+    def get_query_set(self, request):
+        qs = super(PaperAdmin, self).get_queryset(request)
+        return qs.extra(
+            where=["papers_statusdata.id is null OR papers_statusdata.id = ( "
                    "select max(papers_statusdata.id) from papers_statusdata "
-                   "where papers_statusdata.paper_id = papers_paper.id ) OR "
-                   "papers_statusdata.id is null",
-                   "papers_statustested.id = ( "
+                   "where papers_statusdata.paper_id = papers_paper.id )",
+                   "papers_statustested.id is null OR papers_statustested.id = ( "
                    "select max(papers_statustested.id) from papers_statustested "
-                   "where papers_statustested.paper_id = papers_paper.id ) OR "
-                   "papers_statustested.id is null"],
+                   "where papers_statustested.paper_id = papers_paper.id )"],
             tables=["papers_statusdata", "papers_statustested"]
         )
 

--- a/papers/views.py
+++ b/papers/views.py
@@ -5,7 +5,7 @@ from django.http.request import QueryDict
 
 from papers.models import Paper
 import operator
-import urllib2,re
+import urllib2, re
 
 from phenotypes.models import Observable2
 from conditions.models import ConditionType
@@ -19,20 +19,19 @@ from cStringIO import StringIO
 from zipfile import ZipFile
 
 
-
 class PaperIndexView(generic.ListView):
     """A virtual class."""
     model = Paper
     template_name = 'papers/index.html'
     context_object_name = 'papers_list'
 
-    the_filter = False # this should be overloaded
-    GOT = False # for caching multiple requests
-    template_ref = None # for tweaking with the template
+    the_filter = False  # this should be overloaded
+    GOT = False  # for caching multiple requests
+    template_ref = None  # for tweaking with the template
 
     def get_queryset(self):
 
-        got=self.scrub_GET()
+        got = self.scrub_GET()
         if 's' in got:
             papers=[] # hold list of paper ids
 


### PR DESCRIPTION
Papers in the admin interface were not showing statuses automatically, but only after you sort by either the data status or the tested status columns (and actually, it only worked when you sort by the column that has a missing status). The fix turned out to be just renaming get_queryset method to get_query_set. I think this is a bug in django.